### PR TITLE
Note custom terminals with no cmd option

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ Terminal:new {
 }
 ```
 
+If you want to spawn a custom terminal without running any command, you can omit the `cmd` option.
+
 #### Custom terminal usage
 
 ```lua


### PR DESCRIPTION
I spent a long time trying to understand how to do this because when I read the docs I though the `cmd` argument was required. Perhaps this is me being silly, so feel free to ignore if so, but I wanted to make the README explicit.